### PR TITLE
Simplify installation instructions

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,9 +4,7 @@
   <h3>Welcome to the Jelly Tutorial!</h3>
   <p><a href="https://github.com/DennisMitchell/jellylanguage/">Jelly</a> is a recreational programming language created by <a href="https://codegolf.stackexchange.com/users/12012/dennis">Dennis Mitchell</a> for code golf, a competition to write the shortest code to complete a certain task. It is a <a href="https://en.wikipedia.org/wiki/Tacit_programming">tacit</a> programming language and is inspired by <a href="https://www.jsoftware.com/#/">J</a>, a practical tacit language.</p>
   <p>Jelly uses a custom <a href="https://en.wikipedia.org/wiki/SBCS">Single Byte Character Set (SBCS)</a>, so each of its characters take one byte (this is important as code golf is usually scored in bytes, and not characters). Installation instructions are available on its <a href="https://github.com/DennisMitchell/jellylanguage/">GitHub repository</a>:</p>
-  <p><pre><code>git clone -q https://github.com/DennisMitchell/jellylanguage.git
-cd jellylanguage
-pip3 install --upgrade --user .
+  <p><pre><code>pip3 install --upgrade --user git+https://github.com/DennisMitchell/jellylanguage.git
 jelly eun '“3ḅaė;œ»'</code></pre></p>
   <p>This should output <code>Hello, World!</code> to the console.</p>
   <p>Alternatively, you can run Jelly on Dennis's own <a href="https://tio.run/#jelly">Try It Online!</a>, or the interface on this site <a href="/tio">here</a>, which uses TIO's API.</p>


### PR DESCRIPTION
This is pip's recommended way of installing from git repositories unless you intend to develop on the package.